### PR TITLE
Fix bug compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MKDIR=mkdir
 
 BUILD_DIR=build
 
-CFLAGS=-fno-common -Os -g -mcpu=cortex-m3 -mthumb -mthumb-interwork
+CFLAGS=-fno-common -Os -g -mcpu=cortex-m3 -mthumb -mthumb-interwork  --specs=nosys.specs
 
 SOURCES=main.c stm32f1xx_hal_msp.c stm32f1xx_it.c system_stm32f1xx.c usbd_cdc_interface.c usbd_conf.c usbd_desc.c
 


### PR DESCRIPTION
/usr/bin/../lib/gcc/arm-none-eabi/4.9.3/../../../../arm-none-eabi/lib/armv7-m/libg.a(lib_a-exit.o): In function `exit':
exit.c:(.text.exit+0x16): undefined reference to`_exit'
collect2: error: ld returned 1 exit status
make: **\* [main.elf] Ошибка 1
